### PR TITLE
add handling for files that start at non zero time

### DIFF
--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -461,7 +461,7 @@ def frames_to_kbits(
                     last_frame_size = frame.size
                     break
 
-        yield (second-seconds_offset), int(size * 8 / 1000)
+        yield (second - seconds_offset), int(size * 8 / 1000)
 
 
 def downscale_bitrate(

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -433,7 +433,7 @@ def frames_to_kbits(
     last_frame_size = 0
 
     # loop over every second
-    for second in range(seconds_start+seconds_offset, seconds_end + seconds_offset + 1):
+    for second in range(seconds_start + seconds_offset, seconds_end + seconds_offset + 1):
 
         # restore size of a saved frame from last iteration
         # if it's for the current second

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -350,7 +350,7 @@ def create_progress(duration: int):
         if frame:
             if offset == -1:
                 offset = frame.time
-            percent = round(((frame.time-offset) / duration) * 100.0, 1)
+            percent = round(((frame.time - offset) / duration) * 100.0, 1)
             if percent > last_percent:
                 print_progress(percent)
                 last_percent = percent


### PR DESCRIPTION
This adds handling for files that start at a time other than zero (issue #20) by using the time of the first frame as an offset (rounded down).

This also fixes the progress report on the command line using the same method.