### PR TITLE
Make backend initialization optional

### DIFF
--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -96,19 +96,6 @@ except ImportError as err:
     matplotlib = None
     exit_with_error("Missing package 'python3-matplotlib'")
 
-# init backend
-try:
-    if is_wsl():
-        backend = "TkAgg"
-    else:
-        backend = "Qt5Agg"
-    matplotlib.use(backend)
-    import matplotlib.pyplot as matplot  # type: ignore
-except ImportError as err:
-    # satisfy undefined variable warnings
-    matplot = None
-    exit_with_error(err.msg)
-
 # check for ffprobe in path
 if not shutil.which("ffprobe"):
     exit_with_error("Missing ffprobe from package 'ffmpeg'")
@@ -629,6 +616,21 @@ def draw_horizontal_line_with_text(
 
 def main():
     args = parse_arguments()
+    
+    # check if an output is requested, otherwise try to initialize backend, and exit if it fails 
+    if not args.otuput:
+        # init backend
+        try:
+            if is_wsl():
+                backend = "TkAgg"
+            else:
+                backend = "Qt5Agg"
+            matplotlib.use(backend)
+            import matplotlib.pyplot as matplot  # type: ignore
+        except ImportError as err:
+            # satisfy undefined variable warnings
+            matplot = None
+            exit_with_error(err.msg)
 
     # if the output is raw xml, just call the function and exit
     if args.format == "xml_raw":

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -629,8 +629,6 @@ def main():
                 backend = "Qt5Agg"
             matplotlib.use(backend)
         except ImportError as err:
-            # satisfy undefined variable warnings
-            matplot = None
             exit_with_error(err.msg)
 
     # if the output is raw xml, just call the function and exit

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -91,13 +91,13 @@ if util.find_spec("PyQt5") is None:
 # check for matplot lib
 try:
     import matplotlib  # type: ignore
+    import matplotlib.pyplot as matplot  # type: ignore
 except ImportError as err:
     # satisfy undefined variable warnings
     matplotlib = None
+    matplot = None
     exit_with_error("Missing package 'python3-matplotlib'")
 
-import matplotlib.pyplot as matplot # type: ignore
-    
 # check for ffprobe in path
 if not shutil.which("ffprobe"):
     exit_with_error("Missing ffprobe from package 'ffmpeg'")
@@ -581,7 +581,7 @@ def add_area(
     # then work using that as an offset.
     frames_list = frames if isinstance(frames, list) else list(frames)
     offset = math.floor(frames_list[0].time)
-    
+
     bitrates = OrderedDict(frames_to_kbits(frames_list, 0, duration, offset))
     bitrate_max = max(bitrates.values())
     bitrate_mean = int(statistics.mean(bitrates.values()))
@@ -618,9 +618,9 @@ def draw_horizontal_line_with_text(
 
 def main():
     args = parse_arguments()
-    
-    # check if an output is requested, otherwise try to initialize backend, and exit if it fails 
-    if not args.otuput:
+
+    # check if an output is requested, otherwise try to initialize backend, and exit if it fails
+    if not args.output:
         # init backend
         try:
             if is_wsl():

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -96,6 +96,8 @@ except ImportError as err:
     matplotlib = None
     exit_with_error("Missing package 'python3-matplotlib'")
 
+import matplotlib.pyplot as matplot # type: ignore
+    
 # check for ffprobe in path
 if not shutil.which("ffprobe"):
     exit_with_error("Missing ffprobe from package 'ffmpeg'")
@@ -626,7 +628,6 @@ def main():
             else:
                 backend = "Qt5Agg"
             matplotlib.use(backend)
-            import matplotlib.pyplot as matplot  # type: ignore
         except ImportError as err:
             # satisfy undefined variable warnings
             matplot = None


### PR DESCRIPTION
Graphical backend is optional if user only wants the graph as an output, changed backend initialization location. Now it is located in the main function, after the arguments are parsed, so that it is only loaded when necessary, i.e. when no output has been declared.

This also allows the program to be run on headless clients, i.e. webservers that can use it to display the graph.