### PR TITLE
Fix ylims, enhance plot with transparency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,5 +128,5 @@ plotbitrate frames.xml
 Show the bitrate, but fill the area below the curve with a solid color.
 
 ```
-plotbitrate input.mkv --solid
+plotbitrate --solid input.mkv
 ```

--- a/README.md
+++ b/README.md
@@ -124,3 +124,9 @@ Show bitrate graph from raw xml.
 ```
 plotbitrate frames.xml
 ```
+
+Show the bitrate, but fill the area below the curve with a solid color.
+
+```
+plotbitrate input.mkv --solid
+```


### PR DESCRIPTION
Bitrate Viewer fills the area below the curve with a partially transparent colour. I believe this has always helped visualisation and analysis of the bitrate as oscillations are way more apparent. I think plotbitrate would benefit by having the same by default.

- Set the default ymin to zero. I don't believe a floating bitrate plot makes any sense by default.
- Move set_ylim call after the plot has been drawn. It was not working (for me).
- Make the area below the curve slightly transparent to improve visualisation of oscillations.
- Add `--solid` to preserve the old behaviour.

Examples:
Some short clip:
![short_clip](https://github.com/zeroepoch/plotbitrate/assets/55701024/178d4ba4-b216-4511-98d9-4fcb4e825d0a)

Long clip, a lot of oscillation:
- The new default: ![long_tsp](https://github.com/zeroepoch/plotbitrate/assets/55701024/70f2ee85-d14a-4af9-b311-ed6c6f0f8143)
- With `--solid` (just like trunk): ![long_solid](https://github.com/zeroepoch/plotbitrate/assets/55701024/ba5173a2-2928-4210-87d9-fdebc01b1e4a)