### PR TITLE
Bring your own ffprobe via environment variable, fixing #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,14 @@ Show the bitrate, but fill the area below the curve with a solid color.
 ```
 plotbitrate --solid input.mkv
 ```
+
+It's possible to specify a custom `FFPROBE_PATH` in case you don't have it on your `PATH` or want a custom `ffprobe`:
+
+```
+# Unix
+FFPROBE_PATH=/tmp/ffprobe plotbitrate input.mkv
+
+# Windows
+set FFPROBE_PATH=C:\temp\ffmpeg\bin\ffprobe.exe
+plotbitrate input.mkv
+```

--- a/plotbitrate.py
+++ b/plotbitrate.py
@@ -95,8 +95,12 @@ except ImportError as err:
     matplot = None
     exit_with_error("Missing package 'python3-matplotlib'")
 
+
+# bring your own ffprobe, if you want
+ffprobe = os.environ.get('FFPROBE_PATH', 'ffprobe')
+
 # check for ffprobe in path
-if not shutil.which("ffprobe"):
+if not shutil.which(ffprobe):
     exit_with_error("Missing ffprobe from package 'ffmpeg'")
 
 
@@ -193,7 +197,7 @@ def open_ffprobe_get_format(file_path: str) -> subprocess.Popen:
     for file_path and returns the process.
     """
     return subprocess.Popen(
-        ["ffprobe",
+        [ffprobe,
          "-hide_banner",
          "-loglevel", "error",
          "-show_entries", "format",
@@ -212,7 +216,7 @@ def open_ffprobe_get_frames(
     file_path and returns the process.
     """
     return subprocess.Popen(
-        ["ffprobe",
+        [ffprobe,
          "-hide_banner",
          "-loglevel", "error",
          "-select_streams", stream_selector,
@@ -247,7 +251,7 @@ def save_raw_xml(
         f.truncate()
 
         with subprocess.Popen(
-                ["ffprobe",
+                [ffprobe,
                  "-hide_banner",
                  "-loglevel", "error",
                  "-select_streams", stream_selector,


### PR DESCRIPTION
As mentioned in #31, I need to specify a path to ffprobe. Here, I'm taking the environment variable approach, but if any other approach seems more suitable, please don't hesitate to change it!